### PR TITLE
Feat: Improve Resource Descriptions and README

### DIFF
--- a/src/rendering/components.ts
+++ b/src/rendering/components.ts
@@ -17,6 +17,22 @@ export const VALID_COMPONENT_TYPES: ComponentType[] = [
   // 'pathItems' is technically allowed but we handle paths separately
 ];
 
+// Simple descriptions for component types
+const componentTypeDescriptions: Record<ComponentType, string> = {
+  schemas: 'Reusable data structures (models)',
+  responses: 'Reusable API responses',
+  parameters: 'Reusable request parameters (query, path, header, cookie)',
+  examples: 'Reusable examples of media type payloads',
+  requestBodies: 'Reusable request body definitions',
+  headers: 'Reusable header definitions for responses',
+  securitySchemes: 'Reusable security scheme definitions (e.g., API keys, OAuth2)',
+  links: 'Reusable descriptions of links between responses and operations',
+  callbacks: 'Reusable descriptions of callback operations',
+  // pathItems: 'Reusable path item definitions (rarely used directly here)' // Excluded as per comment above
+};
+// Use a Map for safer lookups against prototype pollution
+const componentDescriptionsMap = new Map(Object.entries(componentTypeDescriptions));
+
 /**
  * Wraps an OpenAPIV3.ComponentsObject to make it renderable.
  * Handles listing the available component types.
@@ -43,11 +59,16 @@ export class RenderableComponents implements RenderableSpecObject {
 
     let listText = 'Available Component Types:\n\n';
     availableTypes.sort().forEach(type => {
-      listText += `- ${type}\n`;
+      const description = componentDescriptionsMap.get(type) ?? 'Unknown component type'; // Removed unnecessary 'as ComponentType'
+      listText += `- ${type}: ${description}\n`;
     });
 
-    // Use the new hint generator structure
-    listText += generateListHint(context, { itemType: 'componentType' });
+    // Use the new hint generator structure, providing the first type as an example
+    const firstTypeExample = availableTypes.length > 0 ? availableTypes[0] : undefined;
+    listText += generateListHint(context, {
+      itemType: 'componentType',
+      firstItemExample: firstTypeExample,
+    });
 
     return [
       {
@@ -126,10 +147,12 @@ export class RenderableComponentMap implements RenderableSpecObject {
       listText += `- ${name}\n`;
     });
 
-    // Use the new hint generator structure, providing parent type
+    // Use the new hint generator structure, providing parent type and first name as example
+    const firstNameExample = names.length > 0 ? names[0] : undefined;
     listText += generateListHint(context, {
       itemType: 'componentName',
       parentComponentType: this.componentType,
+      firstItemExample: firstNameExample,
     });
 
     return [

--- a/src/rendering/path-item.ts
+++ b/src/rendering/path-item.ts
@@ -43,15 +43,21 @@ export class RenderablePathItem implements RenderableSpecObject {
       ];
     }
 
-    // Generate hint first using the new structure
+    // Sort methods first to get the correct example
+    methods.sort();
+    const firstMethodExample = methods.length > 0 ? methods[0] : undefined;
+
+    // Generate hint using the new structure, providing the first *sorted* method as an example
     const hint = generateListHint(context, {
       itemType: 'pathMethod',
       parentPath: this.path, // Use the stored raw path
+      firstItemExample: firstMethodExample,
     });
     // Hint includes leading newline, so start output with it directly
     let outputLines: string[] = [hint.trim(), '']; // Trim leading newline from hint for first line
 
-    methods.sort().forEach(method => {
+    // Iterate over the already sorted methods
+    methods.forEach(method => {
       const operation = this.getOperation(method);
       // Use summary or operationId (via getOperationSummary)
       const summaryText = getOperationSummary(operation);

--- a/test/__tests__/unit/rendering/components.test.ts
+++ b/test/__tests__/unit/rendering/components.test.ts
@@ -40,13 +40,18 @@ describe('RenderableComponents (List Types)', () => {
     expect(result[0].renderAsList).toBe(true);
     expect(result[0].isError).toBeUndefined();
     expect(result[0].data).toContain('Available Component Types:');
-    // Check sorted types
-    expect(result[0].data).toMatch(/-\s+examples\n/); // Empty but present
-    expect(result[0].data).toMatch(/-\s+parameters\n/);
-    expect(result[0].data).toMatch(/-\s+responses\n/);
-    expect(result[0].data).toMatch(/-\s+schemas\n/);
+    // Check sorted types with descriptions
+    expect(result[0].data).toMatch(/-\s+examples: Reusable examples of media type payloads\n/);
+    expect(result[0].data).toMatch(
+      /-\s+parameters: Reusable request parameters \(query, path, header, cookie\)\n/
+    );
+    expect(result[0].data).toMatch(/-\s+responses: Reusable API responses\n/);
+    expect(result[0].data).toMatch(/-\s+schemas: Reusable data structures \(models\)\n/);
     expect(result[0].data).not.toContain('- securitySchemes'); // Missing type
-    expect(result[0].data).toContain("Hint: Use 'openapi://components/{type}'");
+    // Check hint with example
+    expect(result[0].data).toContain(
+      "Hint: Use 'openapi://components/{type}' to view details for a specific component type. (e.g., openapi://components/examples)"
+    );
   });
 
   it('should handle empty components object', () => {
@@ -121,7 +126,10 @@ describe('RenderableComponentMap (List/Detail Names)', () => {
       expect(result[0].data).toContain('Available schemas:');
       expect(result[0].data).toMatch(/-\s+Error\n/); // Sorted
       expect(result[0].data).toMatch(/-\s+User\n/);
-      expect(result[0].data).toContain("Hint: Use 'openapi://components/schemas/{name}'");
+      // Check hint with example
+      expect(result[0].data).toContain(
+        "Hint: Use 'openapi://components/schemas/{name}' to view details for a specific schema. (e.g., openapi://components/schemas/Error)"
+      );
     });
 
     it('should list component names correctly (parameters)', () => {
@@ -131,7 +139,10 @@ describe('RenderableComponentMap (List/Detail Names)', () => {
       expect(result[0].uriSuffix).toBe(paramsUriSuffix);
       expect(result[0].data).toContain('Available parameters:');
       expect(result[0].data).toMatch(/-\s+userIdParam\n/);
-      expect(result[0].data).toContain("Hint: Use 'openapi://components/parameters/{name}'");
+      // Check hint with example
+      expect(result[0].data).toContain(
+        "Hint: Use 'openapi://components/parameters/{name}' to view details for a specific parameter. (e.g., openapi://components/parameters/userIdParam)"
+      );
     });
 
     it('should handle empty component map', () => {

--- a/test/__tests__/unit/rendering/path-item.test.ts
+++ b/test/__tests__/unit/rendering/path-item.test.ts
@@ -49,8 +49,9 @@ describe('RenderablePathItem', () => {
       // Define expected output lines based on the new format and builder logic
       // generateListHint uses buildOperationUriSuffix which encodes the path
       // Since rawPath is '/items', encoded is 'items'.
+      // The first sorted method is 'delete'.
       const expectedHint =
-        "Hint: Use 'openapi://paths/items/{method}' to view details for a specific operation.";
+        "Hint: Use 'openapi://paths/items/{method}' to view details for a specific operation. (e.g., openapi://paths/items/delete)";
       const expectedLineDelete = 'DELETE'; // No summary/opId
       const expectedLineGet = 'GET: Get Item'; // Summary exists
       const expectedLinePost = 'POST: Create Item'; // Summary exists


### PR DESCRIPTION
This PR implements improvements based on user feedback:

- Updates MCP resource descriptions in `src/index.ts` to be more informative (dynamic field/type lists, concrete examples, multi-value examples).
- Enhances list view hints (`src/rendering/*`) to include example URIs and component type descriptions.
- Updates unit tests (`test/__tests__/unit/rendering/*`) to match new output formats.
- Updates `README.md` with clearer configuration examples, explanations of multi-value parameters (`*`), and details on resource completions.