### PR TITLE
fix(deps): migrate from deprecated API to registerResource

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "homepage": "https://github.com/kadykov/mcp-openapi-schema-explorer#readme",
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.10.1",
+    "@modelcontextprotocol/sdk": "^1.13.0",
     "js-yaml": "^4.1.0",
     "openapi-types": "^12.1.3",
     "swagger2openapi": "7.0.8",

--- a/src/index.ts
+++ b/src/index.ts
@@ -91,7 +91,7 @@ async function main(): Promise<void> {
         field: (): string[] => Object.keys(transformedSpec), // Use transformedSpec
       },
     });
-    server.resource(
+    server.registerResource(
       'openapi-field', // Unique ID for the resource registration
       fieldTemplate,
       {
@@ -109,7 +109,7 @@ async function main(): Promise<void> {
         path: (): string[] => Object.keys(transformedSpec.paths ?? {}).map(encodeUriPathComponent), // Use imported function directly
       },
     });
-    server.resource(
+    server.registerResource(
       'openapi-path-methods',
       pathTemplate,
       {
@@ -139,7 +139,7 @@ async function main(): Promise<void> {
         ],
       },
     });
-    server.resource(
+    server.registerResource(
       'openapi-operation-detail',
       operationTemplate,
       {
@@ -164,7 +164,7 @@ async function main(): Promise<void> {
         },
       },
     });
-    server.resource(
+    server.registerResource(
       'openapi-component-list',
       componentMapTemplate,
       {
@@ -210,7 +210,7 @@ async function main(): Promise<void> {
         },
       },
     });
-    server.resource(
+    server.registerResource(
       'openapi-component-detail',
       componentDetailTemplate,
       {


### PR DESCRIPTION
Migrate all resource registrations from the deprecated `server.resource()` method to the new `server.registerResource()` API introduced in SDK 1.13.0. This change prevents future breakage when the deprecated API is removed.

Update minimum @modelcontextprotocol/sdk dependency from ^1.10.1 to ^1.13.0, which is the first version that provides the registerResource method.