### PR TITLE
fix: return empty tools/list for Codex compatibility

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { McpServer, ResourceTemplate } from '@modelcontextprotocol/sdk/server/mcp.js'; // Import ResourceTemplate
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
 import { OpenAPI } from 'openapi-types'; // Import OpenAPIV3 as well
 import { loadConfig } from './config.js';
 
@@ -221,6 +222,11 @@ async function main(): Promise<void> {
       },
       componentDetailHandler.handleRequest
     );
+
+    // Workaround for Codex: it calls tools/list on startup and treats -32601 as a fatal error.
+    // Register tools capability + empty handler so resource-only servers stay compatible.
+    server.server.registerCapabilities({ tools: {} });
+    server.server.setRequestHandler(ListToolsRequestSchema, () => ({ tools: [] }));
 
     // Start server
     const transport = new StdioServerTransport();


### PR DESCRIPTION
Codex calls `tools/list` on every MCP server at startup and treats `-32601 Method not found` as a fatal error, refusing to connect.

This server is resource-only, so the SDK never registers a `tools/list` handler.

Fix: register the `tools` capability and return `{"tools":[]}` to satisfy clients that unconditionally probe this method.