### PR TITLE
test: add Xquik OpenAPI 3.1 e2e fixture

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6342,9 +6342,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.18",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
-      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
+      "version": "4.12.27",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.27.tgz",
+      "integrity": "sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -11420,12 +11420,13 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -12516,14 +12517,14 @@
       "license": "MIT"
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -12535,13 +12536,13 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"

--- a/test/__tests__/e2e/spec-loading.test.ts
+++ b/test/__tests__/e2e/spec-loading.test.ts
@@ -170,4 +170,67 @@ describe('E2E Tests for Spec Loading Scenarios', () => {
       });
     });
   });
+
+  describe('Local OpenAPI v3.1 Spec (Xquik)', () => {
+    const xquikSpecPath = path.resolve(__dirname, '../../fixtures/xquik-openapi.json');
+    const tweetSearchPath = '/api/v1/x/tweets/search';
+    const encodedTweetSearchPath = encodeURIComponent(tweetSearchPath);
+
+    beforeAll(async () => await setup(xquikSpecPath));
+
+    it('should retrieve the "info" field from Xquik', async () => {
+      if (!client) return;
+      await checkJsonDetailResponse('openapi://info', {
+        title: 'Xquik API',
+        version: '1.0',
+      });
+    });
+
+    it('should retrieve the Xquik tweet search path', async () => {
+      if (!client) return;
+      await checkTextListResponse('openapi://paths', [
+        'GET /api/v1/x/tweets/search',
+        'openapi://paths/{encoded_path}/{method}',
+      ]);
+    });
+
+    it('should expose query parameters for the Xquik tweet search operation', async () => {
+      if (!client) return;
+      await checkJsonDetailResponse(`openapi://paths/${encodedTweetSearchPath}/get`, {
+        operationId: 'searchTweets',
+        parameters: [
+          { name: 'q', in: 'query', required: true },
+          { name: 'queryType', schema: { enum: ['Latest', 'Top'] } },
+          { name: 'limit', schema: { maximum: 200 } },
+          { name: 'fromUser', in: 'query' },
+          { name: 'verifiedOnly', in: 'query' },
+        ],
+        security: [{ apiKey: [] }, { oauthBearer: [] }, {}],
+      });
+    });
+
+    it('should list and retrieve Xquik schema components', async () => {
+      if (!client) return;
+      await checkTextListResponse('openapi://components/schemas', [
+        '- Error',
+        '- PaginatedTweets',
+        '- SearchTweet',
+        '- TweetAuthor',
+      ]);
+      await checkJsonDetailResponse('openapi://components/schemas/PaginatedTweets', {
+        required: ['tweets', 'has_next_page', 'next_cursor'],
+        properties: {
+          tweets: { type: 'array', items: { $ref: '#/components/schemas/SearchTweet' } },
+        },
+      });
+    });
+
+    it('should list Xquik security schemes', async () => {
+      if (!client) return;
+      await checkTextListResponse('openapi://components/securitySchemes', [
+        '- apiKey',
+        '- oauthBearer',
+      ]);
+    });
+  });
 });

--- a/test/fixtures/xquik-openapi.json
+++ b/test/fixtures/xquik-openapi.json
@@ -1,0 +1,203 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Xquik API",
+    "version": "1.0"
+  },
+  "servers": [
+    {
+      "url": "https://xquik.com"
+    }
+  ],
+  "paths": {
+    "/api/v1/x/tweets/search": {
+      "get": {
+        "summary": "Search tweets by query, Tweet ID, X status URL, or account date window",
+        "operationId": "searchTweets",
+        "tags": ["Tweets"],
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "required": true,
+            "description": "Search query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "queryType",
+            "in": "query",
+            "required": false,
+            "description": "Sort order",
+            "schema": {
+              "type": "string",
+              "enum": ["Latest", "Top"],
+              "default": "Latest"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Max tweets to return",
+            "schema": {
+              "type": "integer",
+              "default": 20,
+              "maximum": 200
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TweetFilterFromUser"
+          },
+          {
+            "$ref": "#/components/parameters/TweetFilterVerifiedOnly"
+          }
+        ],
+        "security": [
+          {
+            "apiKey": []
+          },
+          {
+            "oauthBearer": []
+          },
+          {}
+        ],
+        "responses": {
+          "200": {
+            "description": "Search results",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedTweets"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing query",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "parameters": {
+      "TweetFilterFromUser": {
+        "name": "fromUser",
+        "in": "query",
+        "description": "Filter by author username.",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "TweetFilterVerifiedOnly": {
+        "name": "verifiedOnly",
+        "in": "query",
+        "description": "Only return tweets from verified authors.",
+        "schema": {
+          "type": "boolean"
+        }
+      }
+    },
+    "schemas": {
+      "SearchTweet": {
+        "type": "object",
+        "required": ["id", "text", "createdAt", "author"],
+        "properties": {
+          "id": {
+            "type": "string",
+            "example": "1234567890"
+          },
+          "text": {
+            "type": "string",
+            "example": "Just launched our new feature!"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "example": "2025-01-15T12:00:00Z"
+          },
+          "likeCount": {
+            "type": "integer",
+            "example": 42
+          },
+          "author": {
+            "$ref": "#/components/schemas/TweetAuthor"
+          }
+        }
+      },
+      "TweetAuthor": {
+        "type": "object",
+        "required": ["id", "username", "followers", "verified"],
+        "properties": {
+          "id": {
+            "type": "string",
+            "example": "9876543210"
+          },
+          "username": {
+            "type": "string",
+            "example": "elonmusk"
+          },
+          "followers": {
+            "type": "integer",
+            "example": 150000000
+          },
+          "verified": {
+            "type": "boolean",
+            "example": true
+          }
+        }
+      },
+      "PaginatedTweets": {
+        "type": "object",
+        "required": ["tweets", "has_next_page", "next_cursor"],
+        "properties": {
+          "tweets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SearchTweet"
+            }
+          },
+          "has_next_page": {
+            "type": "boolean",
+            "example": true
+          },
+          "next_cursor": {
+            "type": "string",
+            "example": "DAACCgACGRElMJcAAA"
+          }
+        }
+      },
+      "Error": {
+        "type": "object",
+        "required": ["error"],
+        "properties": {
+          "error": {
+            "type": "string",
+            "enum": ["missing_query", "rate_limit_exceeded", "unauthenticated"],
+            "example": "missing_query"
+          }
+        }
+      }
+    },
+    "securitySchemes": {
+      "apiKey": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "X-API-Key"
+      },
+      "oauthBearer": {
+        "type": "http",
+        "scheme": "bearer"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Add a compact OpenAPI 3.1 fixture based on the public Xquik tweet search operation.
- Cover info, path listing, operation parameters, schema components, and security scheme resources in the e2e spec-loading suite.
- Refresh transitive production lock entries for Hono and qs so the project production audit stays clean.

## Validation

- npm ci
- npm run build
- npm run type-check
- npm run lint
- npm run format:check
- npm test
- npm run test:coverage
- production npm audit at high severity
- production license check
- whitespace diff check
