### PR TITLE
test: add Xquik OpenAPI fixture

### DIFF
--- a/test/__tests__/e2e/spec-loading.test.ts
+++ b/test/__tests__/e2e/spec-loading.test.ts
@@ -170,4 +170,40 @@ describe('E2E Tests for Spec Loading Scenarios', () => {
       });
     });
   });
+
+  describe('Local OpenAPI v3.1 Spec with API key security (Xquik)', () => {
+    const xquikSpecPath = path.resolve(__dirname, '../../fixtures/xquik-social-api.json');
+
+    beforeAll(async () => await setup(xquikSpecPath));
+
+    it('should retrieve the "info" field from the Xquik fixture', async () => {
+      if (!client) return;
+      await checkJsonDetailResponse('openapi://info', {
+        title: 'Xquik API',
+        version: '1.0',
+      });
+    });
+
+    it('should retrieve the search path from the Xquik fixture', async () => {
+      if (!client) return;
+      await checkTextListResponse('openapi://paths', [
+        'GET /api/v1/x/tweets/search',
+        'Search tweets by query',
+      ]);
+    });
+
+    it('should expose security schemes from the Xquik fixture', async () => {
+      if (!client) return;
+      await checkTextListResponse('openapi://components', ['- schemas', '- securitySchemes']);
+    });
+
+    it('should get details for the Xquik search operation', async () => {
+      if (!client) return;
+      const encodedPath = encodeURIComponent('api/v1/x/tweets/search');
+      await checkJsonDetailResponse(`openapi://paths/${encodedPath}/get`, {
+        operationId: 'searchTweets',
+        security: [{ apiKey: [] }, { oauthBearer: [] }, {}],
+      });
+    });
+  });
 });

--- a/test/fixtures/xquik-social-api.json
+++ b/test/fixtures/xquik-social-api.json
@@ -1,0 +1,141 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Xquik API",
+    "version": "1.0",
+    "description": "Public social data API fixture for exercising OpenAPI 3.1, API key security, query parameters, and paginated response schemas."
+  },
+  "servers": [
+    {
+      "url": "https://xquik.com"
+    }
+  ],
+  "paths": {
+    "/api/v1/x/tweets/search": {
+      "get": {
+        "operationId": "searchTweets",
+        "summary": "Search tweets by query, Tweet ID, X status URL, or account date window",
+        "security": [
+          {
+            "apiKey": []
+          },
+          {
+            "oauthBearer": []
+          },
+          {}
+        ],
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "required": true,
+            "description": "Search query.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "queryType",
+            "in": "query",
+            "required": false,
+            "description": "Sort order.",
+            "schema": {
+              "type": "string",
+              "enum": ["Latest", "Top"],
+              "default": "Latest"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Max tweets to return.",
+            "schema": {
+              "type": "integer",
+              "default": 20,
+              "maximum": 200
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Search results",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TweetSearchResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing query"
+          },
+          "401": {
+            "description": "Authentication required"
+          },
+          "429": {
+            "description": "Rate limit exceeded"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "apiKey": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "x-api-key"
+      },
+      "oauthBearer": {
+        "type": "http",
+        "scheme": "bearer"
+      }
+    },
+    "schemas": {
+      "TweetSearchResponse": {
+        "type": "object",
+        "required": ["tweets", "has_next_page"],
+        "properties": {
+          "tweets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Tweet"
+            }
+          },
+          "has_next_page": {
+            "type": "boolean"
+          },
+          "next_cursor": {
+            "type": "string"
+          }
+        }
+      },
+      "Tweet": {
+        "type": "object",
+        "required": ["id", "text", "author"],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "text": {
+            "type": "string"
+          },
+          "author": {
+            "type": "object",
+            "required": ["id", "username"],
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "username": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Add a compact Xquik OpenAPI 3.1 fixture that covers API key security, optional bearer auth, query parameters, and paginated response schemas.
- Add e2e coverage to verify info, path listing, component listing, and operation detail access for the fixture.

## Validation

- `npm run build`
- `npx jest test/__tests__/e2e/spec-loading.test.ts --runInBand`
- `npm run format:check`

Duplicate check: no existing Xquik fixture or matching open or closed PR found before opening this PR.
